### PR TITLE
じゃんけんを勝敗がつくまで繰り返せるように変更しました。[山﨑康生]

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -3,75 +3,67 @@ package main
 import (
 	"fmt"
 	"math/rand"
+	"time" // timeパッケージを追加
 )
 
-
 func main() {
+	// 乱数のシードを設定
+	rand.Seed(time.Now().UnixNano())
+
 	var my_hand int
 	var enemyHand int
 	var rspResult int
 
-	fmt.Println("出す手を決めてください")
-	fmt.Println("0:グー 1:チョキ 2:パー")
-	fmt.Scan(&my_hand)
+	for { // 勝敗が決まるまで繰り返す
+		fmt.Println("出す手を決めてください")
+		fmt.Println("0:グー 1:チョキ 2:パー")
+		fmt.Scan(&my_hand)
 
-	enemyHand = getRandom()
-
-	fmt.Println("じゃんけんぽん！")
-	fmt.Println(enemyHand)
-	rspResult = rspBattle(my_hand, enemyHand)
-
-	printResult(rspResult)
-	fmt.Println("また遊んでね！")
-}
-
-func getRandom() int {
-	// 0~2の値を乱数から生成する
-	randomNum := rand.Intn(100)
-	return randomNum % 2
-}
-
-func rspBattle(myHand, enemyHand int) int {
-	// 引き分け:0 勝利:1 敗北:2
-	switch myHand {
-	case 0:
-		switch enemyHand {
-		case 0:
-			return 0
-		case 1:
-			return 1
-		case 2:
-			return 2
-		default:
-			return 999
+		// 入力値のバリデーション
+		if my_hand < 0 || my_hand > 2 {
+			fmt.Println("無効な入力です。0, 1, 2のいずれかを入力してください。")
+			continue // 再度入力を促す
 		}
-	case 1:
-		switch enemyHand {
-		case 0:
-			return 2
-		case 1:
-			return 0
-		case 2:
-			return 1
-		default:
-			return 999
-		}
-	case 2:
-		switch enemyHand {
-		case 0:
-			return 1
-		case 1:
-			return 2
-		case 2:
-			return 0
-		default:
-			return 999
+
+		enemyHand = getRandom()
+
+		fmt.Println("じゃんけんぽん！")
+		fmt.Printf("あなたは %s、相手は %s\n", handToString(my_hand), handToString(enemyHand)) // どちらが出したか表示
+		rspResult = rspBattle(my_hand, enemyHand)
+
+		printResult(rspResult)
+
+		if rspResult != 0 { // 引き分けでなければループを終了
+			break
+		} else {
+			fmt.Println("あいこでしょ！") // 引き分けの場合はもう一度
 		}
 	}
 
-	return 999
+	fmt.Println("また遊んでね！")
 }
 
+// 0~2の値を乱数から生成する
+func getRandom() int {
+	return rand.Intn(3) // 0, 1, 2 のいずれかを返す
+}
+
+// じゃんけんの結果を判定
+func rspBattle(myHand, enemyHand int) int {
+	// 引き分け:0 勝利:1 敗北:2
+	switch {
+	case myHand == enemyHand:
+		return 0 // 引き分け
+	case (myHand == 0 && enemyHand == 1) || // グー vs チョキ
+		(myHand == 1 && enemyHand == 2) || // チョキ vs パー
+		(myHand == 2 && enemyHand == 0): // パー vs グー
+		return 1 // 勝利
+	default:
+		return 2 // 敗北
+	}
+}
+
+// 結果を表示
 func printResult(result int) {
 	if result == 0 {
 		fmt.Println("Draw")
@@ -79,5 +71,19 @@ func printResult(result int) {
 		fmt.Println("You WIN!")
 	} else if result == 2 {
 		fmt.Println("You LOSE")
+	}
+}
+
+// 手の値を文字列に変換するヘルパー関数
+func handToString(hand int) string {
+	switch hand {
+	case 0:
+		return "グー"
+	case 1:
+		return "チョキ"
+	case 2:
+		return "パー"
+	default:
+		return "不明"
 	}
 }


### PR DESCRIPTION
### 対応したissueのURL 
https://github.com/SocSEL-INFOseminar1-2025/rsp-game-go/issues/3
https://github.com/SocSEL-INFOseminar1-2025/rsp-game-go/issues/5
### 対応内容（何に取り組んだか）
現在のプログラムを、勝敗が決まるまでじゃんけんを繰り返すように変更しました。

### 対応方法(どう対処したか具体的に)
main関数のループ化：rspResultが0（引き分け）の間はじゃんけんを続けるようにforループを追加しました。
初期シード設定：rand.Seedを使って乱数のシードを設定し、実行ごとに異なる結果が得られるようにしました。

### レビューしてほしい点（工夫点など）
工夫点としては、イシューのコメントでもあったように、あいこの場合に「あいこでしょ！」が表示されるようにした。

改善点としては、メインを繰り返す形で実装しましたが、関数として独立させた方が可読性が高いかもしれません。また、その他のイシュー（下記のURL）で「任意の回数じゃんけんを繰り返せるようにする」というものがあったので、マージする際には注意してください。
https://github.com/SocSEL-INFOseminar1-2025/rsp-game-go/issues/7
***

## 最終チェックリスト(xでチェックが入ります)
- [x] 対応するissueのリンクは貼りましたか
- [ ] 適切なタイトルをつけましたか（対応内容[対応者名]）
- [ ] レビューアをアサインしましたか（右上のReviewersにhayato-n8810を設定してください）
- [ ] 適切にコメントしていますか
