### PR TITLE
じゃんけんの結果の表示を見やすくする[田井聖凪]

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -11,11 +11,14 @@ func main() {
 	var my_hand int
 	var enemyHand int
 	var rspResult int
+	hand := make(map[int]string) //入力コードから文字に変換
+	hand[0] = "グー"
+	hand[1] = "チョキ"
+	hand[2] = "パー"
 
 	fmt.Println("出す手を決めてください")
 	fmt.Println("0:グー 1:チョキ 2:パー")
 	fmt.Scan(&my_hand)
-
 	enemyHand = getRandom()
 
 	fmt.Print("じゃん")
@@ -23,8 +26,10 @@ func main() {
 	fmt.Print("けん")
 	time.Sleep(500 * time.Millisecond)	//0.5秒待機
 	fmt.Println("ぽん！")
+	time.Sleep(200 * time.Millisecond)	//0.2秒待機
 
-	fmt.Println(enemyHand)
+	fmt.Println("自分の手:" + hand[my_hand])
+	fmt.Println("相手の手:" + hand[enemyHand])
 	rspResult = rspBattle(my_hand, enemyHand)
 	time.Sleep(500 * time.Millisecond)	//0.5秒待機
 	printResult(rspResult)

--- a/src/main.go
+++ b/src/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"math/rand"
+	"time"
 )
 
 
@@ -17,10 +18,15 @@ func main() {
 
 	enemyHand = getRandom()
 
-	fmt.Println("じゃんけんぽん！")
+	fmt.Print("じゃん")
+	time.Sleep(500 * time.Millisecond)	//0.5秒待機
+	fmt.Print("けん")
+	time.Sleep(500 * time.Millisecond)	//0.5秒待機
+	fmt.Println("ぽん！")
+
 	fmt.Println(enemyHand)
 	rspResult = rspBattle(my_hand, enemyHand)
-
+	time.Sleep(500 * time.Millisecond)	//0.5秒待機
 	printResult(rspResult)
 	fmt.Println("また遊んでね！")
 }


### PR DESCRIPTION
### 対応したissueのURL 
https://github.com/SocSEL-INFOseminar1-2025/rsp-game-go/issues/10

### 対応内容（何に取り組んだか）
1.自分の手を入力した後結果表示に時間をかける
実行例
"じゃん"
 　 ↓ 0.5秒後
"じゃんけん"
 　 ↓ 0.5秒後
"じゃんけんぽん！"
2.じゃんけんの手を表示する
実行例
自分の手:グー
相手の手:グー

### 対応方法(どう対処したか具体的に)
1.時間をかける処理はtimeパッケージをimportしてtime.sleepによって0.5秒間表示を遅らせた
2.mapを用いて"0->グー,1->チョキ,2->パー"へと変換した。それによって、自分の手と相手の手のコードを文字として表現することを可能にした

### レビューしてほしい点（工夫点など）
入力した後にすぐ結果が表示されたところを、時間をかけて表示することで実際にじゃんけんしているときと同じように遊ぶこと可能になる
また、自分の手と相手の手を確認できるようにした
***

## 最終チェックリスト(xでチェックが入ります)
- [x] 対応するissueのリンクは貼りましたか
- [ ] 適切なタイトルをつけましたか（対応内容[対応者名]）
- [ ] レビューアをアサインしましたか（右上のReviewersにhayato-n8810を設定してください）
- [ ] 適切にコメントしていますか
