### PR TITLE
何点先取かを決める機能の追加[阿瀬大輔]

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -10,18 +10,37 @@ func main() {
 	var my_hand int
 	var enemyHand int
 	var rspResult int
+	var my_win int
+	var enemy_win int
+	var wintimes int
 
-	fmt.Println("出す手を決めてください")
-	fmt.Println("0:グー 1:チョキ 2:パー")
-	fmt.Scan(&my_hand)
+	fmt.Println("何点先取にしますか")
+	fmt.Scan(&wintimes)
 
-	enemyHand = getRandom()
+	for my_win<wintimes && enemy_win<wintimes{
+		fmt.Println("出す手を決めてください")
+		fmt.Println("0:グー 1:チョキ 2:パー")
+		fmt.Scan(&my_hand)
 
-	fmt.Println("じゃんけんぽん！")
-	fmt.Println(enemyHand)
-	rspResult = rspBattle(my_hand, enemyHand)
+		enemyHand = getRandom()
 
-	printResult(rspResult)
+		fmt.Println("じゃんけんぽん！")
+		fmt.Println(enemyHand)
+		rspResult = rspBattle(my_hand, enemyHand)
+
+		printResult(rspResult)
+		if rspResult == 1 {
+			my_win++
+		}else if rspResult == 2 {
+			enemy_win++
+		}
+	}
+	if my_win == wintimes {
+		fmt.Println("勝利！")
+	}
+	if enemy_win == wintimes {
+		fmt.Println("敗北...")
+	}
 	fmt.Println("また遊んでね！")
 }
 


### PR DESCRIPTION
### 対応したissueのURL 
https://github.com/SocSEL-INFOseminar1-2025/rsp-game-go/issues/13

### 対応内容（何に取り組んだか）
最初に何点先取かを入力できるようにし、その数だけ先に勝ったほうが勝利にした。

### 対応方法(どう対処したか具体的に)
fmt.Scanで何点先取で勝利とするかの数値を入力し、forループで相手と自分どちらの勝利数もそれに足りない間はじゃんけんを繰り返すようにした。

### レビューしてほしい点（工夫点など）
それぞれのじゃんけんの結果と、全体の勝敗結果の出力する文字を変えることで、分かりやすくした。
***

## 最終チェックリスト(xでチェックが入ります)
- [x] 対応するissueのリンクは貼りましたか
- [x] 適切なタイトルをつけましたか（対応内容[対応者名]）
- [x] レビューアをアサインしましたか（右上のReviewersにhayato-n8810を設定してください）
- [x] 適切にコメントしていますか
