### PR TITLE
相手を2人に追加して，3人でプレイできるように変更[水野晴斗]

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -1,83 +1,112 @@
 package main
 
 import (
-	"fmt"
-	"math/rand"
+   "fmt"
+   "math/rand"
 )
 
 
 func main() {
-	var my_hand int
-	var enemyHand int
-	var rspResult int
+   var my_hand int
+   var enemyHand1 int
+   var enemyHand2 int
+   var rspResult int
 
-	fmt.Println("出す手を決めてください")
-	fmt.Println("0:グー 1:チョキ 2:パー")
-	fmt.Scan(&my_hand)
+   fmt.Println("出す手を決めてください")
+   fmt.Println("0:グー 1:チョキ 2:パー")
+   fmt.Scan(&my_hand)
 
-	enemyHand = getRandom()
+   enemyHand1 = getRandom()
+   enemyHand2 = getRandom()
 
-	fmt.Println("じゃんけんぽん！")
-	fmt.Println(enemyHand)
-	rspResult = rspBattle(my_hand, enemyHand)
+   fmt.Println("じゃんけんぽん！")
+   fmt.Println(enemyHand1)
+   fmt.Println(enemyHand2)
+   rspResult = rspBattle_3p(my_hand, enemyHand1, enemyHand2)
 
-	printResult(rspResult)
-	fmt.Println("また遊んでね！")
+   printResult(rspResult)
+   fmt.Println("また遊んでね！")
 }
 
 func getRandom() int {
-	// 0~2の値を乱数から生成する
-	randomNum := rand.Intn(100)
-	return randomNum % 2
+   // 0~2の値を乱数から生成する
+   randomNum := rand.Intn(100)
+   return randomNum % 2
 }
 
 func rspBattle(myHand, enemyHand int) int {
-	// 引き分け:0 勝利:1 敗北:2
-	switch myHand {
-	case 0:
-		switch enemyHand {
-		case 0:
-			return 0
-		case 1:
-			return 1
-		case 2:
-			return 2
-		default:
-			return 999
-		}
-	case 1:
-		switch enemyHand {
-		case 0:
-			return 2
-		case 1:
-			return 0
-		case 2:
-			return 1
-		default:
-			return 999
-		}
-	case 2:
-		switch enemyHand {
-		case 0:
-			return 1
-		case 1:
-			return 2
-		case 2:
-			return 0
-		default:
-			return 999
-		}
-	}
+   // 引き分け:0 勝利:1 敗北:2
+   switch myHand {
+   case 0:
+       switch enemyHand {
+       case 0:
+           return 0
+       case 1:
+           return 1
+       case 2:
+           return 2
+       default:
+           return 999
+       }
+   case 1:
+       switch enemyHand {
+       case 0:
+           return 2
+       case 1:
+           return 0
+       case 2:
+           return 1
+       default:
+           return 999
+       }
+   case 2:
+       switch enemyHand {
+       case 0:
+           return 1
+       case 1:
+           return 2
+       case 2:
+           return 0
+       default:
+           return 999
+       }
+   }
 
-	return 999
+   return 999
+}
+
+func rspBattle_3p(myHand, enemyHand1 int, enemyHand2 int) int {
+   // 引き分け:0 勝利:1 敗北:2
+   if myHand != enemyHand1 && myHand != enemyHand2 && enemyHand1 != enemyHand2 {
+       return 0;
+   }
+
+   if myHand == enemyHand1 && myHand == enemyHand2 {
+       return 0;
+   }
+
+   if myHand == enemyHand1 {
+       return rspBattle(myHand, enemyHand2);
+   }
+
+   if myHand == enemyHand2 {
+       return rspBattle(myHand, enemyHand1);
+   }
+
+   if enemyHand1 == enemyHand2{
+       return rspBattle(myHand, enemyHand1);
+   }
+
+   return 999
 }
 
 func printResult(result int) {
-	if result == 0 {
-		fmt.Println("Draw")
-	} else if result == 1 {
-		fmt.Println("You WIN!")
-	} else if result == 2 {
-		fmt.Println("You LOSE")
-	}
+   if result == 0 {
+       fmt.Println("Draw")
+   } else if result == 1 {
+       fmt.Println("You WIN!")
+   } else if result == 2 {
+       fmt.Println("You LOSE")
+   }
 }
+


### PR DESCRIPTION
### 対応したissueのURL 
https://github.com/SocSEL-INFOseminar1-2025/rsp-game-go/issues/12

### 対応内容（何に取り組んだか）
相手の数を1人から2人に増やして，3人でプレイできるように変更．

### 対応方法(どう対処したか具体的に)
相手の手を示す変数のenemyHand1とenemyHand2を作成．
3人の手がすべて異なる，または，すべて一緒の時はあいこの判定にする．
それ以外の時は，自分の手と，自分の手と異なる相手の手を取得し，2人対戦の勝敗判定関数を用いて勝敗判定を行った．

### レビューしてほしい点（工夫点など）
勝敗判定について，見落としているパターンがないかをレビューしてほしいです．

***

## 最終チェックリスト(xでチェックが入ります)
- [x] 対応するissueのリンクは貼りましたか
- [x] 適切なタイトルをつけましたか（対応内容[対応者名]）
- [x ] レビューアをアサインしましたか（右上のReviewersにhayato-n8810を設定してください）
- [ x] 適切にコメントしていますか
